### PR TITLE
Add documentation build section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,33 @@ pre-commit run --all-files
 
 9. Submit a pull request to the same branch you branched from
 
+## Building and viewing documentation
+
+To build and view the documentation locally:
+
+1. Install documentation dependencies (included with `--dev` flag above):
+
+```bash
+uv sync --frozen --group docs
+```
+
+2. Serve the documentation locally:
+
+```bash
+uv run mkdocs serve
+```
+
+**Note for macOS users**: If you encounter a [Cairo library error](https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/#cairo-library-was-not-found), set the library path before running mkdocs:
+
+```bash
+export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+uv run mkdocs serve
+```
+
+3. Open your browser to `http://127.0.0.1:8000/python-sdk/` to view the documentation
+
+The documentation will auto-reload when you make changes to files in `docs/`, `mkdocs.yml`, or `src/mcp/`.
+
 ## Code Style
 
 - We use `ruff` for linting and formatting


### PR DESCRIPTION
Add documentation build instructions to help contributors build and view docs locally.

## Motivation and Context

Contributors need clear instructions for building and viewing documentation locally during development. The current CONTRIBUTING.md lacks guidance on the documentation workflow, and macOS users encounter Cairo library errors that prevent successful builds.

## How Has This Been Tested?
- [x] Tested mkdocs serve with provided instructions on macOS
- [x] Verified Cairo workaround resolves build failure on macOS
- [x] Confirmed auto-reload functionality works during development
- [x] Validated documentation builds successfully and serves on localhos

## Breaking Changes
None - this is purely additive documentation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The documentation section includes:

- Installation steps for doc dependencies
- Local server setup with uv run mkdocs serve
- macOS-specific Cairo library workaround (DYLD_FALLBACK_LIBRARY_PATH)
- Auto-reload behavior explanation
- Proper browser URL for accessing docs