### PR TITLE
Fix mkdocs build warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ This document contains critical information about working with this codebase. Fo
    - Coverage: test edge cases and errors
    - New features require tests
    - Bug fixes require regression tests
+   - Documentation
+     - Test changes in docs/ and Python docstrings: `uv run mkdocs build`
+     - On macOS: `export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib & uv run mkdocs build`
+     - Fix WARNING and ERROR issues and re-run build until clean
 
 - For commits fixing bugs or adding features based on user reports add:
 

--- a/docs/examples-lowlevel-servers.md
+++ b/docs/examples-lowlevel-servers.md
@@ -1,6 +1,6 @@
 # Low-level server examples
 
-The [low-level server API](/python-sdk/reference/mcp/server/lowlevel/server/) provides maximum control over MCP protocol implementation. Use these patterns when you need fine-grained control or when [`FastMCP`][mcp.server.fastmcp.FastMCP] doesn't meet your requirements.
+The [low-level server API](reference/mcp/server/lowlevel/server.md) provides maximum control over MCP protocol implementation. Use these patterns when you need fine-grained control or when [`FastMCP`][mcp.server.fastmcp.FastMCP] doesn't meet your requirements.
 
 The low-level API provides the foundation that FastMCP is built upon, giving you access to all MCP protocol features with complete control over implementation details.
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -1487,7 +1487,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
                 and simple containers (list, dict) are allowed - no complex nested objects.
 
         Returns:
-            [`ElicitationResult`][mcp.server.fastmcp.utilities.types.ElicitationResult] containing:
+            `ElicitationResult` containing:
 
             - `action`: One of "accept", "decline", or "cancel" indicating user response
             - `data`: The structured response data (only populated if action is "accept")
@@ -1652,7 +1652,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
         return str(self.request_context.request_id)
 
     @property
-    def session(self):
+    def session(self) -> ServerSession:
         """Access to the underlying ServerSession for advanced MCP operations.
 
         This property provides direct access to the [`ServerSession`][mcp.server.session.ServerSession]

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -318,7 +318,7 @@ class ServerSession(
             logger: Optional name to identify the source of the log message.
                 Useful for categorizing logs from different components or modules
                 within your server (e.g., "database", "auth", "tool_handler").
-            related_request_id: Optional [`types.RequestId`][mcp.types.RequestId] linking this log to a specific client request.
+            related_request_id: Optional `types.RequestId` linking this log to a specific client request.
                 Use this to associate log messages with the request they relate to,
                 making it easier to trace request processing and debug issues.
 
@@ -600,7 +600,7 @@ class ServerSession(
             message: The prompt or question to present to the user.
             requestedSchema: A [`types.ElicitRequestedSchema`][mcp.types.ElicitRequestedSchema] 
                 defining the expected response structure according to JSON Schema.
-            related_request_id: Optional [`types.RequestId`][mcp.types.RequestId] linking 
+            related_request_id: Optional `types.RequestId` linking 
                 this elicitation to a specific client request for tracing.
 
         Returns:

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -77,7 +77,7 @@ class RequestContext(Generic[SessionT, LifespanContextT, RequestT]):
     ```
 
     Attributes:
-        request_id: Unique identifier for the current request as a [`RequestId`][mcp.types.RequestId].
+        request_id: Unique identifier for the current request as a `RequestId`.
             Use this for logging, tracing, or linking related operations.
         meta: Optional request metadata including progress tokens and other client-provided
             information. May be `None` if no metadata was provided.


### PR DESCRIPTION
## Summary
- Fixes all warnings in mkdocs build output
- Ensures clean documentation generation

## Changes
- Fixed absolute link to use relative path in `examples-lowlevel-servers.md`
- Added missing return type annotation (`-> ServerSession`) to `session` property
- Removed broken cross-references to type aliases that mkdocstrings can't resolve
- Updated CLAUDE.md with corrected documentation build command

## Test plan
- [x] Run `uv run mkdocs build` - no warnings (only deprecation notice)
- [x] Run `uv run --frozen pytest` - all tests pass